### PR TITLE
Fix vk-bootstrap and Vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,12 +74,8 @@ else(project_build_type MATCHES "debug")
   message(STATUS "Building in release mode")
 endif(project_build_type MATCHES "debug")
 
-if(WIN32)
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
-else(WIN32)
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-endif(WIN32)
-
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 add_subdirectory(external)
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 if(WIN32)
-  # FIXME: how to find OpenVDB on Windows?
-  # set(OpenVDB_INCLUDE_DIR "${CMAKE_SOURCE_DIR}\\external\\OpenVDB\\include")
-  # set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}\\external\\OpenVDB\\lib\\cmake\\OpenVDB")
+  SET(Vcpkg_ROOT "C:\\vcpkg" CACHE STRING "Root dir for Vcpkg")
+  message(STATUS "Using Vcpkg_ROOT: ${Vcpkg_ROOT}")
+  set(CMAKE_TOOLCHAIN_FILE "${Vcpkg_ROOT}\\scripts\\buildsystems\\vcpkg.cmake")
 else(WIN32)
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/usr/local/lib/cmake/OpenVDB")
 endif(WIN32)
@@ -13,7 +13,7 @@ project(volume_restir)
 OPTION(USE_D2D_WSI "Build the project using Direct to Display swapchain" OFF)
 
 find_package(Vulkan REQUIRED)
-# find_package(OpenVDB)
+find_package(OpenVDB)
 
 IF(WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVK_USE_PLATFORM_WIN32_KHR")
@@ -79,4 +79,4 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 add_subdirectory(external)
 add_subdirectory(src)
-# add_subdirectory(test)
+add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -3,3 +3,30 @@ Vulkan implementation of Fast Volume Rendering with Spatiotemporal Reservoir Res
 
 - [Project Pitch](https://github.com/TheSmokeyGuys/Volume-ReSTIR-Vulkan/blob/main/docs/CIS%20565%20Final%20project%20pitch.pdf)
 - [Milestone 1 Presentation](https://github.com/TheSmokeyGuys/Volume-ReSTIR-Vulkan/blob/UserRYang-patch-1/docs/CIS%20565%20Milestone1.pdf)
+
+## Usage
+### Building on Windows
+This project relies on [Vcpkg](https://github.com/microsoft/vcpkg) to provide Windows support. Before building the code, one should make sure a working Vcpkg is installed in the system.
+
+1. Install [OpenVDB](https://www.openvdb.org/) using Vcpkg:
+
+```bash
+vcpkg install openvdb --triplet=x64-windows
+vcpkg integrate install
+```
+
+2. Create a build folder in the project directory.
+
+```bash
+mkdir build; cd build
+```
+
+3. Specify the root directory of Vcpkg in CMake configurations (default to be `C:\vcpkg`):
+
+```bash
+cmake .. -DVcpkg_ROOT=<PATH_TO_VCPKG>
+```
+If using CMake GUI, add a cache entry "Vcpkg_ROOT" of type `STRING` and type in the path to Vcpkg root folder.
+
+4. On CMake GUI, Configure and generate the project.
+5. Open Visual Studio 2019, select `volume_restir` project as startup project, and run the project.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ If using CMake GUI, add a cache entry "Vcpkg_ROOT" of type `STRING` and type in 
 
 4. On CMake GUI, Configure and generate the project.
 5. Open Visual Studio 2019, select `volume_restir` project as startup project, and run the project.
+
+### Building on Linux (Ubuntu)
+Before building, make sure that a working version of OpenVDB has been installed in the system.
+
+```bash
+mkdir build; cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j
+./bin/volume_restir
+```

--- a/external/vk-bootstrap-0.4/CMakeLists.txt
+++ b/external/vk-bootstrap-0.4/CMakeLists.txt
@@ -27,7 +27,11 @@ else ()
   endif()
 endif()
 
-add_library(vk-bootstrap src/VkBootstrap.h src/VkBootstrap.cpp)
+if (MSVC)
+  add_library(vk-bootstrap STATIC src/VkBootstrap.h src/VkBootstrap.cpp)
+else(MSVC)
+  add_library(vk-bootstrap src/VkBootstrap.h src/VkBootstrap.cpp)
+endif(MSVC)
 add_library(vk-bootstrap::vk-bootstrap ALIAS vk-bootstrap)
 
 add_library(vk-bootstrap-compiler-warnings INTERFACE)


### PR DESCRIPTION
Building external targets as dynamic libraries (.dll) has issues on Windows. External targets must have a static lib (.lib) building scheme for Windows support.

Added static lib building support for vk-bootstrap.

Also added CMake options for user-defined vcpkg root dir 