### PR TITLE
Fix Swapchain destructor incorrect order

### DIFF
--- a/src/SwapChain.cpp
+++ b/src/SwapChain.cpp
@@ -125,9 +125,9 @@ void SwapChain::Create() {
 }
 
 void SwapChain::Destroy() {
+  vkb::destroy_swapchain(swapchain_);
   vkDestroySurfaceKHR(renderContext->Instance().instance, vkSurface,
                       renderContext->Instance().allocation_callbacks);
-  vkb::destroy_swapchain(swapchain_);
 }
 
 vkb::Swapchain SwapChain::GetVkBSwapChain() const { return swapchain_; }


### PR DESCRIPTION
Swapchain needs to be destroyed before Vulkan surface KHR.
- address the error: vkDestroySurfaceKHR() called before its associated VkSwapchainKHR was destroyed.